### PR TITLE
Dat-3122-pipenv-gan-model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anonymeter"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="Statice GmbH", email="hello@statice.ai" },
 ]
@@ -22,15 +22,15 @@ classifiers = [
 ]
 
 dependencies = [
-    "scikit-learn==1.1.1",
+    "scikit-learn==1.2.0",
     "numpy==1.22.4",
-    "pandas==1.4.3",
+    "pandas==1.4.4",
     "numexpr==2.8.3",
-    "joblib==1.1.0",
-    "numba==0.55.2",
+    "joblib==1.2.0",
+    "numba>=0.55.2",
     "python-stdnum==1.11",
-    "regex==2022.6.2",
-    "matplotlib==3.5.2",
+    "regex==2022.10.31",
+    "matplotlib==3.7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
1. upgraded versions of requirements to match those of `gan-model`
2. ran jupyter notebook example as first test
3. ran tests - two tests failed related to changes by DS not upgrade
4. upgraded to version 0.1.0 to be consistent with our other modules